### PR TITLE
chore: add lint tooling and CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,42 @@
+name: Lint
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.19.0'
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Run frontend lint
+        run: npm run lint
+        working-directory: frontend
+
+      - name: Check frontend formatting
+        run: npm run format
+        working-directory: frontend
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Run Go formatter check
+        run: make backend/lint
+
+      - name: Run Go tests
+        run: make backend/test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 GO ?= go
+GOFMT ?= gofmt
+GOFILES := $(shell find backend -name '*.go' -not -path '*/vendor/*')
 
-.PHONY: backend/run backend/build backend/test
+.PHONY: backend/run backend/build backend/test backend/fmt backend/lint
 
 backend/run:
 	cd backend && $(GO) run ./cmd/server
@@ -10,3 +12,14 @@ backend/build:
 
 backend/test:
 	cd backend && $(GO) test ./...
+
+backend/fmt:
+	$(GOFMT) -w $(GOFILES)
+
+backend/lint:
+	@unformatted=$(shell $(GOFMT) -l $(GOFILES)); \
+	if [ -n "$$unformatted" ]; then \
+		echo "gofmt needed on:"; \
+		echo "$$unformatted"; \
+		exit 1; \
+	fi

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ npm run lint
 ## バックエンド開発 (Go)
 `Makefile` を利用すると Go サーバのビルドや起動が簡単です。
 
+![Lint Status](https://github.com/uoxou-moe/rabbit-rtc/actions/workflows/lint.yml/badge.svg)
+
 ```bash
 make backend/run   # サーバ起動 (デフォルトは http://localhost:8080)
 make backend/build # バイナリビルド

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --check .",
+    "format:fix": "prettier --write .",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,16 +18,12 @@ function App() {
       </div>
       <h1>Vite + React</h1>
       <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
+        <button onClick={() => setCount((count) => count + 1)}>count is {count}</button>
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
       </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <p className="read-the-docs">Click on the Vite and React logos to learn more</p>
     </>
   )
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ]
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## 概要
- フロントエンドの ESLint/Prettier コマンドと Go の gofmt チェックを整備しました。
- GitHub Actions で lint/format/tests を実行する CI を追加し、README にステータスバッジを掲載しました。

## 関連Issue / チケット
- #3
- #4

## 変更内容
- `frontend/package.json` に `lint:fix` / `format(:fix)` を追加し、Prettier 実行で `App.tsx` と `tsconfig.json` を整形
- `Makefile` に `backend/fmt`・`backend/lint` を追加して gofmt 実行とチェックをコマンド化
- `.github/workflows/lint.yml` を新設し、 Node/Go の lint・テストを自動実行
- `README.md` に CI バッジを追加

## 動作確認
- [ ] ビルド
- [x] テスト (`make backend/test`)
- [x] 動作確認 (`npm run lint`, `npm run format`, `make backend/lint`)

## その他（レビュアーへの注意点など）
- 今後バンドル CI 等を追加する場合は同ワークフローに統合、または別ワークフローを検討してください。
