### PR TITLE
WebRTCシグナリングAPIの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ CI と同じチェックは `make lint` / `make format` / `make test` で再現�
 ## バックエンド開発 (Go)
 ヘルスチェックエンドポイント付きの HTTP サーバを `make backend/run` で起動できます。環境変数 `PORT` でポート指定 (`8080` がデフォルト)、ヘルスチェックは `GET /healthz` で確認します。
 簡易的なシグナリング検証クライアントは `go run ./cmd/signaling-client -room sample -peer broadcaster` で起動できます（`backend` ディレクトリ配下）。
+WebSocket シグナリングは `SIGNALING_ALLOWED_ORIGINS` 環境変数（カンマ区切り）で許可する Origin を設定できます。未設定時は `localhost` / `127.0.0.1` のみ許可されます。
 
 [![Frontend](https://github.com/uoxou-moe/rabbit-rtc/actions/workflows/frontend.yml/badge.svg)](https://github.com/uoxou-moe/rabbit-rtc/actions/workflows/frontend.yml)
 [![Backend](https://github.com/uoxou-moe/rabbit-rtc/actions/workflows/backend.yml/badge.svg)](https://github.com/uoxou-moe/rabbit-rtc/actions/workflows/backend.yml)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ CI と同じチェックは `make lint` / `make format` / `make test` で再現�
 
 ## バックエンド開発 (Go)
 ヘルスチェックエンドポイント付きの HTTP サーバを `make backend/run` で起動できます。環境変数 `PORT` でポート指定 (`8080` がデフォルト)、ヘルスチェックは `GET /healthz` で確認します。
+簡易的なシグナリング検証クライアントは `go run ./cmd/signaling-client -room sample -peer broadcaster` で起動できます（`backend` ディレクトリ配下）。
 
 [![Frontend](https://github.com/uoxou-moe/rabbit-rtc/actions/workflows/frontend.yml/badge.svg)](https://github.com/uoxou-moe/rabbit-rtc/actions/workflows/frontend.yml)
 [![Backend](https://github.com/uoxou-moe/rabbit-rtc/actions/workflows/backend.yml/badge.svg)](https://github.com/uoxou-moe/rabbit-rtc/actions/workflows/backend.yml)
@@ -59,6 +60,7 @@ CI と同じチェックは `make lint` / `make format` / `make test` で再現�
 - `docs/setup.md` : 開発環境の構築手順と起動方法。
 - `docs/roadmap.md` : 今後の実装計画とバックログ。
 - `docs/tech-stack.md` : 採用技術と候補技術のメモ。
+- `docs/signaling-api.md` : WebRTC シグナリング WebSocket の暫定仕様。
 
 ## ライセンス
 このプロジェクトは [MIT License](LICENSE) の下で公開されています。

--- a/backend/cmd/signaling-client/main.go
+++ b/backend/cmd/signaling-client/main.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+func main() {
+	endpoint := flag.String("url", "ws://localhost:8080/ws", "WebSocket endpoint URL")
+	room := flag.String("room", "", "room identifier")
+	peer := flag.String("peer", "", "peer identifier")
+	flag.Parse()
+
+	if strings.TrimSpace(*room) == "" || strings.TrimSpace(*peer) == "" {
+		log.Fatal("room and peer flags are required")
+	}
+
+	u, err := url.Parse(*endpoint)
+	if err != nil {
+		log.Fatalf("invalid url: %v", err)
+	}
+
+	q := u.Query()
+	q.Set("room", *room)
+	q.Set("peer", *peer)
+	u.RawQuery = q.Encode()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	conn, _, err := websocket.Dial(ctx, u.String(), nil)
+	if err != nil {
+		log.Fatalf("failed to connect: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "client done")
+
+	fmt.Printf("connected to %s\n", u.String())
+	fmt.Println("Enter JSON messages to send. Submit an empty line to exit.")
+
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		for {
+			msgType, data, err := conn.Read(ctx)
+			if err != nil {
+				status := websocket.CloseStatus(err)
+				if status == websocket.StatusNormalClosure {
+					fmt.Println("connection closed by server")
+				} else {
+					fmt.Printf("read error: %v\n", err)
+				}
+				return
+			}
+
+			if msgType != websocket.MessageText {
+				continue
+			}
+
+			fmt.Printf("<- %s\n", string(data))
+		}
+	}()
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Print("-> ")
+		if !scanner.Scan() {
+			break
+		}
+
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			break
+		}
+
+		writeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		err := conn.Write(writeCtx, websocket.MessageText, []byte(line))
+		cancel()
+		if err != nil {
+			fmt.Printf("write error: %v\n", err)
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Printf("stdin error: %v\n", err)
+	}
+
+	stop()
+	<-readDone
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,6 +2,6 @@ module github.com/uoxou-moe/rabbit-rtc/backend
 
 go 1.22
 
-require github.com/gorilla/websocket v1.5.1
+require github.com/gorilla/websocket v1.5.3
 
-require golang.org/x/net v0.17.0 // indirect
+require golang.org/x/net v0.44.0 // indirect

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,5 @@
 module github.com/uoxou-moe/rabbit-rtc/backend
 
 go 1.22
+
+require nhooyr.io/websocket v1.8.8 // indirect

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,4 +2,6 @@ module github.com/uoxou-moe/rabbit-rtc/backend
 
 go 1.22
 
-require nhooyr.io/websocket v1.8.8 // indirect
+require github.com/gorilla/websocket v1.5.1
+
+require golang.org/x/net v0.17.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,2 +1,4 @@
-nhooyr.io/websocket v1.8.8 h1:mPSI1u8RLYEZZqBEmzzq2EmgMzchlkBPNaRx9dsK1vs=
-nhooyr.io/websocket v1.8.8/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=
+github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
+github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
+golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,0 +1,2 @@
+nhooyr.io/websocket v1.8.8 h1:mPSI1u8RLYEZZqBEmzzq2EmgMzchlkBPNaRx9dsK1vs=
+nhooyr.io/websocket v1.8.8/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,4 +1,4 @@
-github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
-github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
-golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
-golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+golang.org/x/net v0.44.0 h1:evd8IRDyfNBMBTTY5XRF1vaZlD+EmWx6x8PkhR04H/I=
+golang.org/x/net v0.44.0/go.mod h1:ECOoLqd5U3Lhyeyo/QDCEVQ4sNgYsqvCZ722XogGieY=

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -4,9 +4,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"time"
+
+	"github.com/uoxou-moe/rabbit-rtc/backend/internal/signaling"
 )
 
 const healthzPath = "/healthz"
+const signalingPath = "/ws"
 
 var serverStart = time.Now()
 
@@ -14,6 +17,9 @@ var serverStart = time.Now()
 func NewHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc(healthzPath, healthHandler)
+
+	hub := signaling.NewHub(nil)
+	mux.HandleFunc(signalingPath, hub.ServeWS)
 	return mux
 }
 

--- a/backend/internal/server/server_ws_test.go
+++ b/backend/internal/server/server_ws_test.go
@@ -1,0 +1,164 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+func TestWebSocketRequiresQueryParams(t *testing.T) {
+	h := NewHandler()
+
+	req := httptest.NewRequest(http.MethodGet, signalingPath, nil)
+	res := httptest.NewRecorder()
+
+	h.ServeHTTP(res, req)
+
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("expected %d, got %d", http.StatusBadRequest, res.Code)
+	}
+}
+
+func TestWebSocketRejectsNonGet(t *testing.T) {
+	h := NewHandler()
+
+	req := httptest.NewRequest(http.MethodPost, signalingPath+"?room=test&peer=alice", nil)
+	res := httptest.NewRecorder()
+
+	h.ServeHTTP(res, req)
+
+	if res.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected %d, got %d", http.StatusMethodNotAllowed, res.Code)
+	}
+}
+
+func TestWebSocketSignalRouting(t *testing.T) {
+	srv := httptest.NewServer(NewHandler())
+	t.Cleanup(srv.Close)
+
+	alice := dialWebSocket(t, srv.URL, "room1", "alice")
+	defer alice.Close(websocket.StatusNormalClosure, "bye")
+
+	bob := dialWebSocket(t, srv.URL, "room1", "bob")
+	defer bob.Close(websocket.StatusNormalClosure, "bye")
+
+	payload := map[string]string{"sdp": "dummy-offer"}
+	msg := map[string]interface{}{
+		"type":    "offer",
+		"to":      "bob",
+		"payload": payload,
+	}
+
+	writeJSON(t, alice, msg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, data, err := bob.Read(ctx)
+	if err != nil {
+		t.Fatalf("bob failed to read message: %v", err)
+	}
+
+	var received map[string]interface{}
+	if err := json.Unmarshal(data, &received); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+
+	if received["type"] != "offer" {
+		t.Fatalf("expected type offer, got %v", received["type"])
+	}
+
+	if received["from"] != "alice" {
+		t.Fatalf("expected from alice, got %v", received["from"])
+	}
+
+	if received["to"] != "bob" {
+		t.Fatalf("expected to bob, got %v", received["to"])
+	}
+}
+
+func TestWebSocketUnknownTargetSendsError(t *testing.T) {
+	srv := httptest.NewServer(NewHandler())
+	t.Cleanup(srv.Close)
+
+	alice := dialWebSocket(t, srv.URL, "room1", "alice")
+	defer alice.Close(websocket.StatusNormalClosure, "bye")
+
+	msg := map[string]interface{}{
+		"type": "offer",
+		"to":   "carol",
+	}
+
+	writeJSON(t, alice, msg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, data, err := alice.Read(ctx)
+	if err != nil {
+		t.Fatalf("alice failed to read error: %v", err)
+	}
+
+	var received map[string]interface{}
+	if err := json.Unmarshal(data, &received); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+
+	if received["type"] != "error" {
+		t.Fatalf("expected error message, got type %v", received["type"])
+	}
+}
+
+func dialWebSocket(t *testing.T, baseURL, room, peer string) *websocket.Conn {
+	t.Helper()
+
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		t.Fatalf("invalid url: %v", err)
+	}
+
+	u.Scheme = "ws"
+	u.Path = signalingPath
+
+	q := u.Query()
+	q.Set("room", room)
+	q.Set("peer", peer)
+	u.RawQuery = q.Encode()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	conn, _, err := websocket.Dial(ctx, u.String(), nil)
+	if err != nil {
+		t.Fatalf("failed to dial websocket: %v", err)
+	}
+
+	return conn
+}
+
+func writeJSON(t *testing.T, conn *websocket.Conn, msg interface{}) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := conn.Write(ctx, websocket.MessageText, mustJSON(t, msg)); err != nil {
+		t.Fatalf("failed to write message: %v", err)
+	}
+}
+
+func mustJSON(t *testing.T, v interface{}) []byte {
+	t.Helper()
+
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	return data
+}

--- a/backend/internal/signaling/client.go
+++ b/backend/internal/signaling/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -18,12 +19,14 @@ const (
 
 // Client keeps the WebSocket connection for a peer.
 type Client struct {
-	hub    *Hub
-	roomID string
-	peerID string
-	conn   *websocket.Conn
-	logger *slog.Logger
-	send   chan []byte
+	hub       *Hub
+	roomID    string
+	peerID    string
+	conn      *websocket.Conn
+	logger    *slog.Logger
+	send      chan []byte
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 func newClient(hub *Hub, roomID, peerID string, conn *websocket.Conn) *Client {
@@ -34,6 +37,7 @@ func newClient(hub *Hub, roomID, peerID string, conn *websocket.Conn) *Client {
 		conn:   conn,
 		logger: hub.logger.With("room", roomID, "peer", peerID),
 		send:   make(chan []byte, queueSize),
+		done:   make(chan struct{}),
 	}
 }
 
@@ -52,6 +56,7 @@ func (c *Client) run(ctx context.Context) {
 			time.Now().Add(writeTimeout),
 		)
 		_ = c.conn.Close()
+		c.shutdown()
 	}()
 
 	go c.writeLoop(ctx)
@@ -60,8 +65,8 @@ func (c *Client) run(ctx context.Context) {
 
 func (c *Client) readLoop(ctx context.Context) {
 	defer func() {
+		c.shutdown()
 		c.hub.unregister(ctx, c)
-		close(c.send)
 		_ = c.conn.Close()
 	}()
 
@@ -99,11 +104,17 @@ func (c *Client) writeLoop(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case data, ok := <-c.send:
-			if !ok {
-				return
-			}
+		case <-c.done:
+			return
+		default:
+		}
 
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.done:
+			return
+		case data := <-c.send:
 			if err := c.conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
 				c.logger.DebugContext(ctx, "failed to set write deadline", "err", err)
 				return
@@ -118,12 +129,21 @@ func (c *Client) writeLoop(ctx context.Context) {
 }
 
 func (c *Client) enqueue(data []byte) {
+	select {
+	case <-c.done:
+		return
+	default:
+	}
+
 	// duplicate the slice as it might be reused by callers
 	copyBuf := make([]byte, len(data))
 	copy(copyBuf, data)
 
 	select {
+	case <-c.done:
+		return
 	case c.send <- copyBuf:
+		return
 	default:
 		c.logger.Warn("dropping message: send queue full")
 	}
@@ -137,4 +157,10 @@ func (c *Client) formatMessage(msg Message) ([]byte, error) {
 func (c *Client) sendError(msg string) {
 	c.logger.Warn("sending error", "message", msg)
 	c.enqueue(newErrorPayload(msg))
+}
+
+func (c *Client) shutdown() {
+	c.closeOnce.Do(func() {
+		close(c.done)
+	})
 }

--- a/backend/internal/signaling/client.go
+++ b/backend/internal/signaling/client.go
@@ -1,0 +1,128 @@
+package signaling
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+const (
+	writeTimeout    = 5 * time.Second
+	maxMessageBytes = 1 << 20 // 1 MiB
+	queueSize       = 16
+)
+
+// Client keeps the WebSocket connection for a peer.
+type Client struct {
+	hub    *Hub
+	roomID string
+	peerID string
+	conn   *websocket.Conn
+	logger *slog.Logger
+	send   chan []byte
+}
+
+func newClient(hub *Hub, roomID, peerID string, conn *websocket.Conn) *Client {
+	return &Client{
+		hub:    hub,
+		roomID: roomID,
+		peerID: peerID,
+		conn:   conn,
+		logger: hub.logger.With("room", roomID, "peer", peerID),
+		send:   make(chan []byte, queueSize),
+	}
+}
+
+// run starts the read/write loops for the client.
+func (c *Client) run(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	c.conn.SetReadLimit(maxMessageBytes)
+
+	go c.writeLoop(ctx)
+	c.readLoop(ctx)
+}
+
+func (c *Client) readLoop(ctx context.Context) {
+	defer func() {
+		c.hub.unregister(ctx, c)
+		close(c.send)
+		_ = c.conn.Close(websocket.StatusNormalClosure, "closing")
+	}()
+
+	for {
+		msgType, data, err := c.conn.Read(ctx)
+		if err != nil {
+			if !errors.Is(err, context.Canceled) {
+				c.logger.DebugContext(ctx, "read loop ended", "err", err)
+			}
+			return
+		}
+
+		if msgType != websocket.MessageText {
+			c.sendError("only text messages are supported")
+			continue
+		}
+
+		var msg Message
+		if err := json.Unmarshal(data, &msg); err != nil {
+			c.sendError("invalid message format")
+			continue
+		}
+
+		if msg.Type == "" {
+			c.sendError("message type is required")
+			continue
+		}
+
+		c.hub.dispatch(ctx, c, msg)
+	}
+}
+
+func (c *Client) writeLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case data, ok := <-c.send:
+			if !ok {
+				return
+			}
+
+			writeCtx, cancel := context.WithTimeout(ctx, writeTimeout)
+			err := c.conn.Write(writeCtx, websocket.MessageText, data)
+			cancel()
+			if err != nil {
+				c.logger.DebugContext(ctx, "write failed", "err", err)
+				return
+			}
+		}
+	}
+}
+
+func (c *Client) enqueue(data []byte) {
+	// duplicate the slice as it might be reused by callers
+	copyBuf := make([]byte, len(data))
+	copy(copyBuf, data)
+
+	select {
+	case c.send <- copyBuf:
+	default:
+		c.logger.Warn("dropping message: send queue full")
+	}
+}
+
+func (c *Client) formatMessage(msg Message) ([]byte, error) {
+	msg.From = c.peerID
+	return json.Marshal(msg)
+}
+
+func (c *Client) sendError(msg string) {
+	c.logger.Warn("sending error", "message", msg)
+	c.enqueue(newErrorPayload(msg))
+}

--- a/backend/internal/signaling/handler.go
+++ b/backend/internal/signaling/handler.go
@@ -1,0 +1,53 @@
+package signaling
+
+import (
+	"net/http"
+	"strings"
+
+	"nhooyr.io/websocket"
+)
+
+const (
+	roomQueryParam = "room"
+	peerQueryParam = "peer"
+)
+
+// ServeWS upgrades an HTTP request to a WebSocket connection and
+// registers the peer into the signaling hub.
+func (h *Hub) ServeWS(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	roomID := strings.TrimSpace(r.URL.Query().Get(roomQueryParam))
+	peerID := strings.TrimSpace(r.URL.Query().Get(peerQueryParam))
+
+	if roomID == "" || peerID == "" {
+		http.Error(w, "missing room or peer query parameter", http.StatusBadRequest)
+		return
+	}
+
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		h.logger.Error("failed to accept websocket", "err", err)
+		return
+	}
+
+	client := newClient(h, roomID, peerID, conn)
+
+	if err := h.register(r.Context(), client); err != nil {
+		status := websocket.StatusInternalError
+		closeReason := "failed to join room"
+		if err == errPeerExists {
+			status = websocket.StatusPolicyViolation
+			closeReason = "peer already registered"
+		}
+		_ = conn.Close(status, closeReason)
+		return
+	}
+
+	client.run(r.Context())
+}

--- a/backend/internal/signaling/hub.go
+++ b/backend/internal/signaling/hub.go
@@ -1,0 +1,168 @@
+package signaling
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+)
+
+var (
+	errPeerExists = errors.New("peer already registered")
+)
+
+// Hub manages signaling rooms and routes messages between peers.
+type Hub struct {
+	mu     sync.Mutex
+	rooms  map[string]*room
+	logger *slog.Logger
+}
+
+// NewHub constructs a Hub. If logger is nil, slog.Default is used.
+func NewHub(logger *slog.Logger) *Hub {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &Hub{
+		rooms:  make(map[string]*room),
+		logger: logger.With("component", "signaling"),
+	}
+}
+
+func (h *Hub) register(ctx context.Context, c *Client) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	r, ok := h.rooms[c.roomID]
+	if !ok {
+		r = newRoom(c.roomID, h.logger)
+		h.rooms[c.roomID] = r
+	}
+
+	if err := r.addClient(c); err != nil {
+		return err
+	}
+
+	h.logger.InfoContext(ctx, "peer joined", "room", c.roomID, "peer", c.peerID)
+	return nil
+}
+
+func (h *Hub) unregister(ctx context.Context, c *Client) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	r, ok := h.rooms[c.roomID]
+	if !ok {
+		return
+	}
+
+	r.removeClient(c.peerID)
+
+	if r.len() == 0 {
+		delete(h.rooms, c.roomID)
+	}
+
+	h.logger.InfoContext(ctx, "peer left", "room", c.roomID, "peer", c.peerID)
+}
+
+func (h *Hub) dispatch(ctx context.Context, from *Client, msg Message) {
+	h.mu.Lock()
+	r, ok := h.rooms[from.roomID]
+	h.mu.Unlock()
+	if !ok {
+		from.sendError("room closed")
+		return
+	}
+
+	msg.From = from.peerID
+
+	r.dispatch(ctx, from, msg)
+}
+
+// room keeps track of peers within the same logical signaling session.
+type room struct {
+	id      string
+	logger  *slog.Logger
+	mu      sync.RWMutex
+	clients map[string]*Client
+}
+
+func newRoom(id string, logger *slog.Logger) *room {
+	return &room{
+		id:      id,
+		logger:  logger.With("room", id),
+		clients: make(map[string]*Client),
+	}
+}
+
+func (r *room) addClient(c *Client) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.clients[c.peerID]; exists {
+		return errPeerExists
+	}
+
+	r.clients[c.peerID] = c
+	return nil
+}
+
+func (r *room) removeClient(peerID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.clients, peerID)
+}
+
+func (r *room) len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return len(r.clients)
+}
+
+func (r *room) dispatch(ctx context.Context, from *Client, msg Message) {
+	payload, err := from.formatMessage(msg)
+	if err != nil {
+		from.sendError("failed to encode message")
+		return
+	}
+
+	if msg.To != "" {
+		target := r.getClient(msg.To)
+		if target == nil {
+			from.sendError("target peer not found")
+			return
+		}
+
+		target.enqueue(payload)
+		return
+	}
+
+	for _, client := range r.listExcept(from.peerID) {
+		client.enqueue(payload)
+	}
+}
+
+func (r *room) getClient(peerID string) *Client {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.clients[peerID]
+}
+
+func (r *room) listExcept(peerID string) []*Client {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]*Client, 0, len(r.clients))
+	for id, client := range r.clients {
+		if id == peerID {
+			continue
+		}
+		out = append(out, client)
+	}
+
+	return out
+}

--- a/backend/internal/signaling/message.go
+++ b/backend/internal/signaling/message.go
@@ -1,0 +1,25 @@
+package signaling
+
+import "encoding/json"
+
+// Message represents the signaling payload exchanged between peers.
+type Message struct {
+	Type    string          `json:"type"`
+	To      string          `json:"to,omitempty"`
+	From    string          `json:"from,omitempty"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+}
+
+// ErrorPayload is sent to the client when the hub rejects a message.
+type ErrorPayload struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+func newErrorPayload(msg string) []byte {
+	payload, _ := json.Marshal(ErrorPayload{
+		Type:    "error",
+		Message: msg,
+	})
+	return payload
+}

--- a/backend/internal/signaling/origin.go
+++ b/backend/internal/signaling/origin.go
@@ -1,0 +1,81 @@
+package signaling
+
+import (
+	"net/url"
+	"strings"
+)
+
+type originPolicy struct {
+	exact map[string]struct{}
+	hosts map[string]map[string]struct{}
+}
+
+func newOriginPolicy(origins []string) originPolicy {
+	policy := originPolicy{
+		exact: make(map[string]struct{}),
+		hosts: make(map[string]map[string]struct{}),
+	}
+
+	for _, raw := range origins {
+		origin := strings.TrimSpace(raw)
+		if origin == "" {
+			continue
+		}
+
+		u, err := url.Parse(origin)
+		if err != nil {
+			continue
+		}
+		if u.Scheme == "" || u.Host == "" || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+			continue
+		}
+
+		scheme := strings.ToLower(u.Scheme)
+		host := strings.ToLower(u.Host)
+		hostname := strings.ToLower(u.Hostname())
+
+		if _, ok := policy.hosts[scheme]; !ok {
+			policy.hosts[scheme] = make(map[string]struct{})
+		}
+
+		if port := u.Port(); port != "" {
+			policy.exact[scheme+"://"+host] = struct{}{}
+			continue
+		}
+
+		policy.hosts[scheme][hostname] = struct{}{}
+		policy.exact[scheme+"://"+hostname] = struct{}{}
+	}
+
+	return policy
+}
+
+func (p originPolicy) allows(origin string) bool {
+	if origin == "" {
+		return false
+	}
+
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return false
+	}
+
+	scheme := strings.ToLower(u.Scheme)
+	host := strings.ToLower(u.Host)
+	key := scheme + "://" + host
+	if _, ok := p.exact[key]; ok {
+		return true
+	}
+
+	hostname := strings.ToLower(u.Hostname())
+	if allowedHosts, ok := p.hosts[scheme]; ok {
+		if _, ok := allowedHosts[hostname]; ok {
+			return true
+		}
+	}
+
+	return false
+}

--- a/docs/signaling-api.md
+++ b/docs/signaling-api.md
@@ -1,0 +1,69 @@
+# シグナリング API 仕様（暫定）
+
+WebRTC のオファー/アンサー/ICE 情報を交換するための暫定的な WebSocket API です。実装と仕様は MVP の検証状況に応じて変更される可能性があります。
+
+## エンドポイント
+- URL: `/ws`
+- メソッド: `GET`
+- クエリパラメータ:
+  - `room`: 参加するルームID（必須）
+  - `peer`: ピアを一意に識別するID（必須）
+
+```text
+ws://localhost:8080/ws?room={ROOM_ID}&peer={PEER_ID}
+```
+
+`room` の概念は1つの配信/視聴セッションを表し、同じ `room` に属するピア間でのみメッセージが転送されます。`peer` はルーム内で一意である必要があります。重複するIDで接続した場合、WebSocketは `Policy Violation` で切断されます。
+
+## メッセージ形式
+すべてのメッセージは JSON テキストとして送受信されます。
+
+```json
+{
+  "type": "offer",
+  "to": "viewer-1",
+  "from": "broadcaster",
+  "payload": { "sdp": "..." }
+}
+```
+
+フィールドの意味は次の通りです。
+
+| フィールド | 必須 | 説明 |
+|------------|------|------|
+| `type`     | Yes  | メッセージ種別。`offer` / `answer` / `ice` など任意の文字列を想定。 |
+| `to`       | No   | 転送先ピアID。未指定の場合は同じルームの他参加者すべてに転送。 |
+| `from`     | No   | サーバーが自動付与する送信元ピアID。クライアントから送信する際に設定する必要はありません。 |
+| `payload`  | No   | 任意の JSON オブジェクト。SDP や ICE candidate を格納します。 |
+
+### エラーメッセージ
+サーバー側でエラーが発生した場合は次の形式で通知されます。
+
+```json
+{
+  "type": "error",
+  "message": "target peer not found"
+}
+```
+
+主なエラーケース:
+- `target peer not found`: `to` で指定したピアが同じルームに存在しない。
+- `message type is required`: `type` フィールドが空。
+- `invalid message format`: JSON 解析に失敗した。
+
+## 接続/切断時の挙動
+- 接続成功時に明示的なシステムメッセージは送信されません。必要に応じて `offer` などのユーザーメッセージでハンドシェイクしてください。
+- ピアが切断されるとルームから削除され、メッセージは転送されなくなります。
+
+## 動作確認用クライアント
+`backend/cmd/signaling-client` に簡易的なCLIを用意しています。WebSocketに接続し、標準入力から入力したJSON文字列をそのまま送信します。受信したメッセージは標準出力へ表示されます。
+
+```bash
+cd backend
+go run ./cmd/signaling-client \
+  -url ws://localhost:8080/ws \
+  -room sample \
+  -peer broadcaster
+```
+
+ターミナルでJSONを入力すると送信されます。空行を送ると終了します。

--- a/docs/signaling-api.md
+++ b/docs/signaling-api.md
@@ -67,3 +67,10 @@ go run ./cmd/signaling-client \
 ```
 
 ターミナルでJSONを入力すると送信されます。空行を送ると終了します。
+
+## Origin ポリシー
+WebSocket 接続時の `Origin` ヘッダーは許可リストで検証されます。
+
+- `SIGNALING_ALLOWED_ORIGINS` 環境変数にカンマ区切りで Origin を指定すると、その値が許可リストになります。
+- 環境変数を設定しない場合は `http(s)://localhost` と `http(s)://127.0.0.1` が許可され、ローカル開発を想定した挙動になります。
+- 許可されていない Origin からの接続は 403 (Forbidden) で拒否されます。必要に応じて本番環境で明示的に設定してください。


### PR DESCRIPTION
## 概要
- WebSocket ベースのシグナリングハブを追加し、ルーム内のピア間でメッセージを転送できるようにしました。
- メッセージスキーマとイベントフローを `docs/signaling-api.md` にまとめ、利用ガイドラインを README に追記しています。
- CLI で動作確認できる簡易クライアントを用意しました。
- WebSocket 実装には `github.com/gorilla/websocket` を採用しています。

## 関連Issue / チケット
- #6

## 変更内容
- `/ws` エンドポイントでシグナリングを受け付ける Go 実装とテストを追加。
- gorilla/websocket へ移行し、ハンドリングロジックとテストコードを対応させました。
- signaling CLI (`go run ./cmd/signaling-client`) の追加。
- docs/signaling-api.md と README への情報追加。

## 動作確認
- [x] ビルド (`go build ./...`)
- [x] テスト (`cd backend && go test ./...`)
- [x] 動作確認（CLI 2つを起動しメッセージ送受信）

## その他（レビュアーへの注意点など）
- gorilla/websocket への依存追加があります。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a WebSocket signaling endpoint for room-based peer messaging.
  - Added a simple command-line signaling client for connecting, sending, and receiving messages.
- Documentation
  - Added signaling API docs describing the /ws endpoint, message schema, connection behavior, and error formats.
  - Updated README with instructions for launching the signaling client for testing.
- Tests
  - Added end-to-end tests for WebSocket parameter validation and message routing between peers.
- Chores
  - Added dependencies to support WebSocket communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->