### PR TITLE
feat: add viewer watch page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes, BrowserRouter } from 'react-router-dom'
 import './App.css'
 import BroadcastPage from './features/broadcast/BroadcastPage'
+import ViewerPage from './features/viewer/ViewerPage'
 
 function NotFound() {
   return (
@@ -22,6 +23,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Navigate to="/broadcast" replace />} />
         <Route path="/broadcast" element={<BroadcastPage />} />
+        <Route path="/watch" element={<ViewerPage />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/features/viewer/ViewerPage.css
+++ b/frontend/src/features/viewer/ViewerPage.css
@@ -1,36 +1,52 @@
 .viewer-page {
+  --muted-foreground: #64748b;
+  --border-color: rgba(148, 163, 184, 0.4);
+  position: relative;
+  z-index: 0;
   display: flex;
   flex-direction: column;
   gap: 2rem;
   padding: 2rem clamp(1.5rem, 4vw, 3rem);
   max-width: 1100px;
   margin: 0 auto;
+  min-height: 100vh;
 }
 
-.page-header {
+.viewer-page::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background:
+    radial-gradient(circle at top, rgba(59, 130, 246, 0.12), transparent 55%),
+    radial-gradient(circle at 20% 80%, rgba(20, 184, 166, 0.12), transparent 60%),
+    linear-gradient(180deg, #f8fafc 0%, #e0f2f1 100%);
+}
+
+.viewer-page .page-header {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
 }
 
-.page-title {
+.viewer-page .page-title {
   font-size: clamp(1.75rem, 2.6vw, 2.5rem);
   font-weight: 700;
   margin: 0;
 }
 
-.page-subtitle {
+.viewer-page .page-subtitle {
   margin: 0;
   color: var(--muted-foreground);
 }
 
-.layout {
+.viewer-page .layout {
   display: grid;
   gap: 1.5rem;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
-.panel {
+.viewer-page .panel {
   background: rgba(255, 255, 255, 0.9);
   border-radius: 16px;
   box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
@@ -40,46 +56,46 @@
   gap: 1.25rem;
 }
 
-.panel-title {
+.viewer-page .panel-title {
   margin: 0;
   font-size: 1.25rem;
   font-weight: 600;
 }
 
-.form {
+.viewer-page .form {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.form-field {
+.viewer-page .form-field {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
 
-.form-label {
+.viewer-page .form-label {
   font-weight: 600;
 }
 
-.form-hint {
+.viewer-page .form-hint {
   color: var(--muted-foreground);
   font-size: 0.85rem;
 }
 
-.form-actions {
+.viewer-page .form-actions {
   display: flex;
   gap: 0.75rem;
 }
 
-.controls {
+.viewer-page .controls {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
   align-items: center;
 }
 
-.input {
+.viewer-page .input {
   border-radius: 8px;
   border: 1px solid var(--border-color);
   padding: 0.6rem 0.75rem;
@@ -87,11 +103,11 @@
   background: white;
 }
 
-.input:disabled {
+.viewer-page .input:disabled {
   background: rgba(148, 163, 184, 0.1);
 }
 
-.status-block {
+.viewer-page .status-block {
   background: rgba(15, 23, 42, 0.03);
   border-radius: 12px;
   padding: 1rem;
@@ -100,30 +116,30 @@
   gap: 0.25rem;
 }
 
-.status-label {
+.viewer-page .status-label {
   font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--muted-foreground);
 }
 
-.status-text {
+.viewer-page .status-text {
   margin: 0;
   font-weight: 600;
 }
 
-.status-connection {
+.viewer-page .status-connection {
   margin: 0;
   font-size: 0.95rem;
 }
 
-.status-error {
+.viewer-page .status-error {
   margin: 0;
   color: #dc2626;
   font-size: 0.95rem;
 }
 
-.button {
+.viewer-page .button {
   border: none;
   border-radius: 10px;
   padding: 0.65rem 1.1rem;
@@ -134,54 +150,54 @@
     box-shadow 0.15s ease;
 }
 
-.button:disabled {
+.viewer-page .button:disabled {
   cursor: not-allowed;
   opacity: 0.6;
   transform: none;
   box-shadow: none;
 }
 
-.button-primary {
+.viewer-page .button-primary {
   background: linear-gradient(135deg, #10b981, #14b8a6);
   color: white;
   box-shadow: 0 8px 20px rgba(20, 184, 166, 0.35);
 }
 
-.button-secondary {
+.viewer-page .button-secondary {
   background: #e2e8f0;
   color: #0f172a;
 }
 
-.button-danger {
+.viewer-page .button-danger {
   background: linear-gradient(135deg, #ef4444, #f87171);
   color: white;
   box-shadow: 0 8px 20px rgba(248, 113, 113, 0.35);
 }
 
-.button:not(:disabled):hover {
+.viewer-page .button:not(:disabled):hover {
   transform: translateY(-1px);
 }
 
-.button:not(:disabled):active {
+.viewer-page .button:not(:disabled):active {
   transform: translateY(0);
 }
 
-.slider {
+.viewer-page .slider {
   display: flex;
   align-items: center;
   gap: 0.5rem;
 }
 
-.slider-label {
+.viewer-page .slider-label {
   font-size: 0.9rem;
   color: var(--muted-foreground);
 }
 
-.slider-input {
+.viewer-page .slider-input {
   width: 140px;
 }
 
-.video-wrapper {
+.viewer-page .video-wrapper {
   position: relative;
   width: 100%;
   padding-top: 56.25%;
@@ -193,11 +209,11 @@
   justify-content: center;
 }
 
-.video-wrapper--empty {
+.viewer-page .video-wrapper--empty {
   background: rgba(15, 23, 42, 0.8);
 }
 
-.player {
+.viewer-page .player {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -206,7 +222,7 @@
   background: #111827;
 }
 
-.video-placeholder {
+.viewer-page .video-placeholder {
   position: absolute;
   inset: 0;
   display: flex;
@@ -217,38 +233,25 @@
   letter-spacing: 0.02em;
 }
 
-.muted {
+.viewer-page .muted {
   color: var(--muted-foreground);
   margin: 0;
 }
 
-.text-small {
+.viewer-page .text-small {
   font-size: 0.85rem;
 }
 
-.link {
+.viewer-page .link {
   color: #4f46e5;
   text-decoration: none;
 }
 
-.link:hover {
+.viewer-page .link:hover {
   text-decoration: underline;
 }
 
-:root {
-  --muted-foreground: #64748b;
-  --border-color: rgba(148, 163, 184, 0.4);
-}
-
-body {
-  background:
-    radial-gradient(circle at top, rgba(59, 130, 246, 0.12), transparent 55%),
-    radial-gradient(circle at 20% 80%, rgba(20, 184, 166, 0.12), transparent 60%),
-    linear-gradient(180deg, #f8fafc 0%, #e0f2f1 100%);
-  min-height: 100vh;
-}
-
-.badge {
+.viewer-page .badge {
   display: inline-flex;
   align-items: center;
   padding: 0.15rem 0.6rem;
@@ -257,22 +260,22 @@ body {
   font-weight: 600;
 }
 
-.badge-connected,
-.badge-completed {
+.viewer-page .badge-connected,
+.viewer-page .badge-completed {
   background: rgba(34, 197, 94, 0.15);
   color: #15803d;
 }
 
-.badge-connecting,
-.badge-new,
-.badge-checking {
+.viewer-page .badge-connecting,
+.viewer-page .badge-new,
+.viewer-page .badge-checking {
   background: rgba(59, 130, 246, 0.15);
   color: #1d4ed8;
 }
 
-.badge-disconnected,
-.badge-failed,
-.badge-closed {
+.viewer-page .badge-disconnected,
+.viewer-page .badge-failed,
+.viewer-page .badge-closed {
   background: rgba(248, 113, 113, 0.18);
   color: #b91c1c;
 }
@@ -282,11 +285,11 @@ body {
     padding: 1.5rem 1rem 3rem;
   }
 
-  .panel {
+  .viewer-page .panel {
     padding: 1.5rem;
   }
 
-  .slider-input {
+  .viewer-page .slider-input {
     width: 100px;
   }
 }

--- a/frontend/src/features/viewer/ViewerPage.css
+++ b/frontend/src/features/viewer/ViewerPage.css
@@ -1,0 +1,292 @@
+.viewer-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2rem clamp(1.5rem, 4vw, 3rem);
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.page-title {
+  font-size: clamp(1.75rem, 2.6vw, 2.5rem);
+  font-weight: 700;
+  margin: 0;
+}
+
+.page-subtitle {
+  margin: 0;
+  color: var(--muted-foreground);
+}
+
+.layout {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.panel-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-label {
+  font-weight: 600;
+}
+
+.form-hint {
+  color: var(--muted-foreground);
+  font-size: 0.85rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.input {
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+  background: white;
+}
+
+.input:disabled {
+  background: rgba(148, 163, 184, 0.1);
+}
+
+.status-block {
+  background: rgba(15, 23, 42, 0.03);
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.status-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-foreground);
+}
+
+.status-text {
+  margin: 0;
+  font-weight: 600;
+}
+
+.status-connection {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.status-error {
+  margin: 0;
+  color: #dc2626;
+  font-size: 0.95rem;
+}
+
+.button {
+  border: none;
+  border-radius: 10px;
+  padding: 0.65rem 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
+.button-primary {
+  background: linear-gradient(135deg, #10b981, #14b8a6);
+  color: white;
+  box-shadow: 0 8px 20px rgba(20, 184, 166, 0.35);
+}
+
+.button-secondary {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+.button-danger {
+  background: linear-gradient(135deg, #ef4444, #f87171);
+  color: white;
+  box-shadow: 0 8px 20px rgba(248, 113, 113, 0.35);
+}
+
+.button:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+.button:not(:disabled):active {
+  transform: translateY(0);
+}
+
+.slider {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.slider-label {
+  font-size: 0.9rem;
+  color: var(--muted-foreground);
+}
+
+.slider-input {
+  width: 140px;
+}
+
+.video-wrapper {
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%;
+  background: #0f172a;
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.video-wrapper--empty {
+  background: rgba(15, 23, 42, 0.8);
+}
+
+.player {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: #111827;
+}
+
+.video-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(226, 232, 240, 0.9);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.muted {
+  color: var(--muted-foreground);
+  margin: 0;
+}
+
+.text-small {
+  font-size: 0.85rem;
+}
+
+.link {
+  color: #4f46e5;
+  text-decoration: none;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+:root {
+  --muted-foreground: #64748b;
+  --border-color: rgba(148, 163, 184, 0.4);
+}
+
+body {
+  background:
+    radial-gradient(circle at top, rgba(59, 130, 246, 0.12), transparent 55%),
+    radial-gradient(circle at 20% 80%, rgba(20, 184, 166, 0.12), transparent 60%),
+    linear-gradient(180deg, #f8fafc 0%, #e0f2f1 100%);
+  min-height: 100vh;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.badge-connected,
+.badge-completed {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.badge-connecting,
+.badge-new,
+.badge-checking {
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+}
+
+.badge-disconnected,
+.badge-failed,
+.badge-closed {
+  background: rgba(248, 113, 113, 0.18);
+  color: #b91c1c;
+}
+
+@media (max-width: 600px) {
+  .viewer-page {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .panel {
+    padding: 1.5rem;
+  }
+
+  .slider-input {
+    width: 100px;
+  }
+}

--- a/frontend/src/features/viewer/ViewerPage.tsx
+++ b/frontend/src/features/viewer/ViewerPage.tsx
@@ -1,0 +1,235 @@
+import {
+  type ChangeEvent,
+  type FormEvent,
+  type MouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import './ViewerPage.css'
+import { useViewer } from './useViewer'
+
+function generatePeerId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `viewer-${crypto.randomUUID().slice(0, 8)}`
+  }
+
+  return `viewer-${Math.random().toString(36).slice(2, 10)}`
+}
+
+const DEFAULT_ROOM_ID = 'demo-room'
+
+const ViewerPage = () => {
+  const defaultPeerId = useMemo(() => generatePeerId(), [])
+  const [roomId, setRoomId] = useState(DEFAULT_ROOM_ID)
+  const [peerId, setPeerId] = useState(defaultPeerId)
+  const [muted, setMuted] = useState(true)
+  const [volume, setVolume] = useState(0.8)
+
+  const videoRef = useRef<HTMLVideoElement | null>(null)
+
+  const { remoteStream, phase, status, lastError, connectionState, connect, disconnect } = useViewer({
+    room: roomId.trim(),
+    peerId: peerId.trim(),
+  })
+
+  useEffect(() => {
+    const video = videoRef.current
+    if (!video) {
+      return
+    }
+
+    video.muted = muted
+  }, [muted])
+
+  useEffect(() => {
+    const video = videoRef.current
+    if (!video) {
+      return
+    }
+
+    video.volume = volume
+  }, [volume])
+
+  useEffect(() => {
+    const video = videoRef.current
+    if (!video) {
+      return
+    }
+
+    if (remoteStream) {
+      video.srcObject = remoteStream
+      const playPromise = video.play()
+      if (playPromise && typeof playPromise.then === 'function') {
+        void playPromise.catch(() => {
+          // autoplay restrictions might prevent immediate playback; ignore.
+        })
+      }
+    } else {
+      video.srcObject = null
+    }
+  }, [remoteStream])
+
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      disconnect()
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+      disconnect()
+    }
+  }, [disconnect])
+
+  const canEditSettings = phase === 'idle'
+  const isWatching = phase !== 'idle'
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (phase !== 'idle') {
+      return
+    }
+    connect()
+  }
+
+  const handleActionClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      if (!isWatching) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+      disconnect()
+    },
+    [disconnect, isWatching],
+  )
+
+  const handleMuteToggle = () => {
+    setMuted((prev) => !prev)
+  }
+
+  const handleVolumeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = Number(event.target.value)
+    if (Number.isNaN(value)) {
+      return
+    }
+    setVolume(value)
+    if (value > 0 && muted) {
+      setMuted(false)
+    }
+  }
+
+  return (
+    <div className="viewer-page">
+      <header className="page-header">
+        <h1 className="page-title">視聴ページ</h1>
+        <p className="page-subtitle">配信者のストリームに接続し、低遅延で視聴します。</p>
+      </header>
+
+      <div className="layout">
+        <section className="panel">
+          <h2 className="panel-title">接続設定</h2>
+          <form className="form" onSubmit={handleSubmit}>
+            <label className="form-field">
+              <span className="form-label">ルームID</span>
+              <input
+                className="input"
+                type="text"
+                value={roomId}
+                onChange={(event) => setRoomId(event.target.value)}
+                disabled={!canEditSettings}
+                required
+              />
+            </label>
+
+            <label className="form-field">
+              <span className="form-label">ピアID</span>
+              <input
+                className="input"
+                type="text"
+                value={peerId}
+                onChange={(event) => setPeerId(event.target.value)}
+                disabled={!canEditSettings}
+                required
+              />
+              <span className="form-hint">視聴者としてシグナリングに登録されるIDです。</span>
+            </label>
+
+            <div className="form-actions">
+              <button
+                type={isWatching ? 'button' : 'submit'}
+                className={`button ${isWatching ? 'button-danger' : 'button-primary'}`}
+                onClick={handleActionClick}
+              >
+                {isWatching ? '視聴を終了' : '視聴を開始'}
+              </button>
+            </div>
+          </form>
+
+          <div className="status-block">
+            <span className="status-label">状態</span>
+            <p className="status-text">{status}</p>
+            {connectionState ? (
+              <p className="status-connection">
+                接続ステータス: <span className={`badge badge-${connectionState}`}>{connectionState}</span>
+              </p>
+            ) : null}
+            {lastError ? <p className="status-error">{lastError}</p> : null}
+          </div>
+
+          <div className="controls">
+            <button
+              type="button"
+              className="button button-secondary"
+              onClick={handleMuteToggle}
+              disabled={!remoteStream}
+            >
+              {muted ? 'ミュート解除' : 'ミュート'}
+            </button>
+            <label className="slider">
+              <span className="slider-label">音量</span>
+              <input
+                className="slider-input"
+                type="range"
+                min={0}
+                max={1}
+                step={0.05}
+                value={volume}
+                onChange={handleVolumeChange}
+                disabled={!remoteStream}
+              />
+            </label>
+          </div>
+        </section>
+
+        <section className="panel">
+          <h2 className="panel-title">ライブ視聴</h2>
+          <div className={`video-wrapper ${remoteStream ? '' : 'video-wrapper--empty'}`}>
+            <video ref={videoRef} className="player" playsInline autoPlay controls={false} />
+            {!remoteStream ? <p className="video-placeholder">ストリームの受信を待機しています...</p> : null}
+          </div>
+          <p className="muted text-small">
+            ブラウザの自動再生制限により、音声を再生するには「ミュート解除」を押してください。接続終了後はブラウザのタブを閉じるか、上の
+            ボタンで視聴を停止してください。
+          </p>
+        </section>
+      </div>
+
+      <section className="panel">
+        <h2 className="panel-title">配信者への接続状況</h2>
+        <p className="muted text-small">
+          ルームIDとピアIDが配信者と一致している必要があります。配信者がオンラインの場合は自動的に接続が開始されます。
+        </p>
+        <p className="muted text-small">
+          配信者用のページは <a className="link" href="/broadcast">/broadcast</a> からアクセスできます。
+        </p>
+      </section>
+    </div>
+  )
+}
+
+export default ViewerPage

--- a/frontend/src/features/viewer/ViewerPage.tsx
+++ b/frontend/src/features/viewer/ViewerPage.tsx
@@ -30,10 +30,11 @@ const ViewerPage = () => {
 
   const videoRef = useRef<HTMLVideoElement | null>(null)
 
-  const { remoteStream, phase, status, lastError, connectionState, connect, disconnect } = useViewer({
-    room: roomId.trim(),
-    peerId: peerId.trim(),
-  })
+  const { remoteStream, phase, status, lastError, connectionState, connect, disconnect } =
+    useViewer({
+      room: roomId.trim(),
+      peerId: peerId.trim(),
+    })
 
   useEffect(() => {
     const video = videoRef.current
@@ -175,7 +176,8 @@ const ViewerPage = () => {
             <p className="status-text">{status}</p>
             {connectionState ? (
               <p className="status-connection">
-                接続ステータス: <span className={`badge badge-${connectionState}`}>{connectionState}</span>
+                接続ステータス:{' '}
+                <span className={`badge badge-${connectionState}`}>{connectionState}</span>
               </p>
             ) : null}
             {lastError ? <p className="status-error">{lastError}</p> : null}
@@ -210,7 +212,9 @@ const ViewerPage = () => {
           <h2 className="panel-title">ライブ視聴</h2>
           <div className={`video-wrapper ${remoteStream ? '' : 'video-wrapper--empty'}`}>
             <video ref={videoRef} className="player" playsInline autoPlay controls={false} />
-            {!remoteStream ? <p className="video-placeholder">ストリームの受信を待機しています...</p> : null}
+            {!remoteStream ? (
+              <p className="video-placeholder">ストリームの受信を待機しています...</p>
+            ) : null}
           </div>
           <p className="muted text-small">
             ブラウザの自動再生制限により、音声を再生するには「ミュート解除」を押してください。接続終了後はブラウザのタブを閉じるか、上の
@@ -225,7 +229,11 @@ const ViewerPage = () => {
           ルームIDとピアIDが配信者と一致している必要があります。配信者がオンラインの場合は自動的に接続が開始されます。
         </p>
         <p className="muted text-small">
-          配信者用のページは <a className="link" href="/broadcast">/broadcast</a> からアクセスできます。
+          配信者用のページは{' '}
+          <a className="link" href="/broadcast">
+            /broadcast
+          </a>{' '}
+          からアクセスできます。
         </p>
       </section>
     </div>

--- a/frontend/src/features/viewer/useViewer.ts
+++ b/frontend/src/features/viewer/useViewer.ts
@@ -1,0 +1,436 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { buildSignalingUrl } from '../broadcast/useBroadcaster'
+
+const DEBUG = import.meta.env.DEV
+
+const debugLog = (...args: unknown[]) => {
+  if (!DEBUG) {
+    return
+  }
+  console.info('[useViewer]', ...args)
+}
+
+const ICE_SERVERS: RTCIceServer[] = [{ urls: 'stun:stun.l.google.com:19302' }]
+
+type ViewerPhase = 'idle' | 'connecting' | 'waiting-offer' | 'answering' | 'watching'
+
+type SignalingMessage = {
+  type: string
+  from?: string
+  to?: string
+  payload?: unknown
+  message?: unknown
+}
+
+interface UseViewerOptions {
+  room: string
+  peerId: string
+}
+
+interface UseViewerResult {
+  remoteStream: MediaStream | null
+  phase: ViewerPhase
+  status: string
+  lastError: string | null
+  connectionState: RTCPeerConnectionState | null
+  connect: () => void
+  disconnect: () => void
+}
+
+export function useViewer({ room, peerId }: UseViewerOptions): UseViewerResult {
+  const [phase, setPhase] = useState<ViewerPhase>('idle')
+  const [status, setStatus] = useState('未接続')
+  const [lastError, setLastError] = useState<string | null>(null)
+  const [connectionState, setConnectionState] = useState<RTCPeerConnectionState | null>(null)
+  const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null)
+
+  const socketRef = useRef<WebSocket | null>(null)
+  const peerConnectionRef = useRef<RTCPeerConnection | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const broadcasterRef = useRef<string | null>(null)
+  const unmountedRef = useRef(false)
+
+  const safeSetPhase = useCallback((value: ViewerPhase) => {
+    if (unmountedRef.current) {
+      return
+    }
+    setPhase(value)
+  }, [])
+
+  const safeSetStatus = useCallback((value: string) => {
+    if (unmountedRef.current) {
+      return
+    }
+    setStatus(value)
+  }, [])
+
+  const safeSetLastError = useCallback((value: string | null) => {
+    if (unmountedRef.current) {
+      return
+    }
+    setLastError(value)
+  }, [])
+
+  const safeSetConnectionState = useCallback((value: RTCPeerConnectionState | null) => {
+    if (unmountedRef.current) {
+      return
+    }
+    setConnectionState(value)
+  }, [])
+
+  const safeSetRemoteStream = useCallback((stream: MediaStream | null) => {
+    if (unmountedRef.current) {
+      return
+    }
+    setRemoteStream(stream)
+  }, [])
+
+  const closeSocket = useCallback(() => {
+    const socket = socketRef.current
+    if (!socket) {
+      return
+    }
+
+    socket.onopen = null
+    socket.onmessage = null
+    socket.onerror = null
+    socket.onclose = null
+
+    if (
+      socket.readyState === WebSocket.CONNECTING ||
+      socket.readyState === WebSocket.OPEN
+    ) {
+      debugLog('closing socket')
+      socket.close(1000, 'viewer disconnected')
+    }
+
+    socketRef.current = null
+  }, [])
+
+  const cleanupPeerConnection = useCallback(() => {
+    const pc = peerConnectionRef.current
+    if (pc) {
+      debugLog('cleaning up peer connection')
+      pc.onicecandidate = null
+      pc.ontrack = null
+      pc.onconnectionstatechange = null
+      try {
+        pc.close()
+      } catch (error) {
+        debugLog('peer connection close error', error)
+      }
+    }
+
+    peerConnectionRef.current = null
+    broadcasterRef.current = null
+
+    const stream = streamRef.current
+    if (stream) {
+      stream.getTracks().forEach((track) => {
+        try {
+          track.stop()
+        } catch (error) {
+          debugLog('failed to stop remote track', error)
+        }
+      })
+    }
+
+    streamRef.current = null
+    safeSetRemoteStream(null)
+    safeSetConnectionState(null)
+  }, [safeSetConnectionState, safeSetRemoteStream])
+
+  const sendMessage = useCallback((message: Record<string, unknown>) => {
+    const socket = socketRef.current
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      debugLog('signaling socket is not open; skipping message', message)
+      return
+    }
+
+    try {
+      socket.send(JSON.stringify(message))
+      debugLog('sent message', message)
+    } catch (error) {
+      console.warn('Failed to send signaling message', error)
+    }
+  }, [])
+
+  const createPeerConnection = useCallback(() => {
+    let pc = peerConnectionRef.current
+    if (pc) {
+      return pc
+    }
+
+    debugLog('creating peer connection')
+    pc = new RTCPeerConnection({ iceServers: ICE_SERVERS })
+    peerConnectionRef.current = pc
+
+    pc.ontrack = (event) => {
+      debugLog('remote track received', event.streams)
+      if (event.streams && event.streams[0]) {
+        streamRef.current = event.streams[0]
+        safeSetRemoteStream(event.streams[0])
+      } else {
+        let stream = streamRef.current
+        if (!stream) {
+          stream = new MediaStream()
+          streamRef.current = stream
+        }
+        stream.addTrack(event.track)
+        safeSetRemoteStream(stream)
+      }
+    }
+
+    pc.onicecandidate = (event) => {
+      if (!event.candidate) {
+        return
+      }
+      const broadcaster = broadcasterRef.current
+      if (!broadcaster) {
+        debugLog('no broadcaster to send ice candidate')
+        return
+      }
+      debugLog('local ice candidate', event.candidate)
+      sendMessage({ type: 'ice', to: broadcaster, payload: event.candidate })
+    }
+
+    pc.onconnectionstatechange = () => {
+      const state = pc?.connectionState ?? null
+      debugLog('connection state changed', state)
+      if (state) {
+        safeSetConnectionState(state)
+      } else {
+        safeSetConnectionState(null)
+      }
+
+      if (!state) {
+        return
+      }
+
+      if (state === 'connected') {
+        safeSetPhase('watching')
+        safeSetStatus('配信を視聴しています')
+      } else if (state === 'failed') {
+        safeSetLastError('ピア接続が失敗しました')
+        safeSetStatus('ピア接続が失敗しました')
+        cleanupPeerConnection()
+        safeSetPhase('waiting-offer')
+      } else if (state === 'disconnected' || state === 'closed') {
+        safeSetStatus('接続が終了しました。再開を待機しています...')
+        cleanupPeerConnection()
+        safeSetPhase('waiting-offer')
+      }
+    }
+
+    return pc
+  }, [cleanupPeerConnection, safeSetConnectionState, safeSetLastError, safeSetPhase, safeSetRemoteStream, safeSetStatus, sendMessage])
+
+  const requestOffer = useCallback(() => {
+    debugLog('requesting offer from broadcaster')
+    sendMessage({ type: 'viewer-ready' })
+  }, [sendMessage])
+
+  const handleOffer = useCallback(
+    async (sender: string, payload: unknown) => {
+      if (!payload || typeof payload !== 'object') {
+        return
+      }
+
+      const description = payload as RTCSessionDescriptionInit
+      if (!description.sdp || description.type !== 'offer') {
+        return
+      }
+
+      const pc = createPeerConnection()
+      broadcasterRef.current = sender
+
+      try {
+        safeSetPhase('answering')
+        safeSetStatus('オファーを処理しています...')
+        await pc.setRemoteDescription(description)
+        if (unmountedRef.current) {
+          return
+        }
+
+        const answer = await pc.createAnswer()
+        await pc.setLocalDescription(answer)
+        if (unmountedRef.current) {
+          return
+        }
+
+        sendMessage({ type: 'answer', to: sender, payload: answer })
+        safeSetStatus('アンサーを送信しました。接続を確立しています...')
+      } catch (error) {
+        console.error('Failed to handle offer', error)
+        safeSetLastError('オファーの処理中にエラーが発生しました')
+        safeSetStatus('オファーの処理に失敗しました')
+        cleanupPeerConnection()
+        safeSetPhase('waiting-offer')
+      }
+    },
+    [cleanupPeerConnection, createPeerConnection, safeSetLastError, safeSetPhase, safeSetStatus, sendMessage],
+  )
+
+  const handleRemoteIce = useCallback(async (payload: unknown) => {
+    const pc = peerConnectionRef.current
+    if (!pc || !payload || typeof payload !== 'object') {
+      return
+    }
+
+    try {
+      await pc.addIceCandidate(payload as RTCIceCandidateInit)
+    } catch (error) {
+      console.error('Failed to add remote ICE candidate', error)
+      safeSetLastError('リモート ICE candidate の適用に失敗しました')
+    }
+  }, [safeSetLastError])
+
+  const handleBroadcasterLeft = useCallback(() => {
+    debugLog('broadcaster left or ended')
+    cleanupPeerConnection()
+    safeSetStatus('配信が終了しました。再開を待機しています...')
+    safeSetPhase('waiting-offer')
+  }, [cleanupPeerConnection, safeSetPhase, safeSetStatus])
+
+  const handleMessage = useCallback(
+    (raw: string) => {
+      debugLog('message received', raw)
+      let message: SignalingMessage
+      try {
+        message = JSON.parse(raw) as SignalingMessage
+      } catch (error) {
+        console.warn('Received malformed signaling payload', raw, error)
+        return
+      }
+
+      const sender = message.from
+      switch (message.type) {
+        case 'offer':
+          if (sender) {
+            void handleOffer(sender, message.payload)
+          }
+          break
+        case 'ice':
+          void handleRemoteIce(message.payload)
+          break
+        case 'broadcaster-ready':
+          safeSetStatus('配信者がオンラインになりました。接続準備中...')
+          requestOffer()
+          break
+        case 'bye':
+        case 'broadcaster-left':
+          handleBroadcasterLeft()
+          break
+        case 'error': {
+          if (typeof message.message === 'string' && message.message.length > 0) {
+            safeSetLastError(message.message)
+            return
+          }
+          if (message.payload && typeof message.payload === 'object') {
+            const payload = message.payload as { message?: unknown }
+            if (typeof payload.message === 'string' && payload.message.length > 0) {
+              safeSetLastError(payload.message)
+              return
+            }
+          }
+          safeSetLastError('シグナリングサーバからエラーを受信しました')
+          break
+        }
+        default:
+          debugLog('unsupported message type', message.type)
+      }
+    },
+    [handleBroadcasterLeft, handleOffer, handleRemoteIce, requestOffer, safeSetLastError, safeSetStatus],
+  )
+
+  const connect = useCallback(() => {
+    if (phase !== 'idle') {
+      debugLog('connect skipped due to phase', phase)
+      return
+    }
+
+    const trimmedRoom = room.trim()
+    const trimmedPeer = peerId.trim()
+    if (trimmedRoom.length === 0 || trimmedPeer.length === 0) {
+      const message = 'ルームIDとピアIDを入力してください'
+      safeSetLastError(message)
+      safeSetStatus(message)
+      return
+    }
+
+    safeSetPhase('connecting')
+    safeSetStatus('シグナリングサーバへ接続中...')
+    safeSetLastError(null)
+    safeSetConnectionState(null)
+
+    const url = buildSignalingUrl(trimmedRoom, trimmedPeer)
+    debugLog('connecting to signaling server', url)
+
+    const socket = new WebSocket(url)
+    socketRef.current = socket
+
+    socket.onopen = () => {
+      debugLog('socket opened')
+      if (unmountedRef.current) {
+        socket.close()
+        return
+      }
+      safeSetPhase('waiting-offer')
+      safeSetStatus('配信者からのオファーを待機しています...')
+      requestOffer()
+    }
+
+    socket.onmessage = (event) => {
+      handleMessage(event.data)
+    }
+
+    socket.onerror = (event) => {
+      console.error('Signaling socket error', event)
+      safeSetLastError('シグナリング通信でエラーが発生しました')
+    }
+
+    socket.onclose = () => {
+      debugLog('socket closed')
+      cleanupPeerConnection()
+      socketRef.current = null
+      if (unmountedRef.current) {
+        return
+      }
+      safeSetPhase('idle')
+      safeSetStatus('シグナリング接続が終了しました')
+    }
+  }, [cleanupPeerConnection, handleMessage, phase, peerId, requestOffer, room, safeSetConnectionState, safeSetLastError, safeSetPhase, safeSetStatus])
+
+  const disconnect = useCallback(() => {
+    debugLog('disconnect invoked')
+    const socket = socketRef.current
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      sendMessage({ type: 'viewer-left' })
+    }
+    cleanupPeerConnection()
+    closeSocket()
+    safeSetPhase('idle')
+    safeSetStatus('視聴を終了しました')
+  }, [cleanupPeerConnection, closeSocket, safeSetPhase, safeSetStatus, sendMessage])
+
+  useEffect(() => {
+    unmountedRef.current = false
+    return () => {
+      unmountedRef.current = true
+      disconnect()
+    }
+  }, [disconnect])
+
+  return useMemo(
+    () => ({
+      remoteStream,
+      phase,
+      status,
+      lastError,
+      connectionState,
+      connect,
+      disconnect,
+    }),
+    [connect, connectionState, disconnect, lastError, phase, remoteStream, status],
+  )
+}

--- a/frontend/src/features/viewer/useViewer.ts
+++ b/frontend/src/features/viewer/useViewer.ts
@@ -376,6 +376,8 @@ export function useViewer({ room, peerId }: UseViewerOptions): UseViewerResult {
 
     const trimmedRoom = room.trim()
     const trimmedPeer = peerId.trim()
+    // TODO(#28): 同一ピアIDを利用する視聴者がソケット切断される問題を解消する。
+    // https://github.com/uoxou-moe/rabbit-rtc/issues/28
     if (trimmedRoom.length === 0 || trimmedPeer.length === 0) {
       const message = 'ルームIDとピアIDを入力してください'
       safeSetLastError(message)


### PR DESCRIPTION
## Summary
- add a viewer-facing watch page that connects to the signaling server and plays the remote stream
- implement a reusable WebRTC viewer hook with playback controls and status reporting
- register the new /watch route alongside the existing broadcaster dashboard

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d51d30e9288322b0ba96cd8e07a160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Viewer page at /watch for watching live streams with start/stop controls, connection status, and error feedback.
  - Mute toggle and volume slider (auto-unmute when increasing).
  - Editable room and viewer IDs before connecting; sensible defaults.
  - Video player with placeholder when no stream; improved autoplay handling to reduce playback interruptions.
  - UI includes status/info sections and Japanese strings.

- Style
  - Responsive, card-based layout with panels, badges, and buttons; improved typography and mobile adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->